### PR TITLE
Add .gitignore file with common exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# OS bestanden
+.DS_Store
+Thumbs.db
+
+# IDE / Editor bestanden
+.vscode/
+.idea/
+*.swp
+
+# Logbestanden
+*.log
+error_log
+debug.log
+
+# Composer dependencies
+/vendor/
+
+# Uploads en tijdelijke bestanden
+uploads/
+tmp/
+cache/
+img/
+
+# Environment/config bestanden
+.env
+.env.*
+config.php
+db.php
+
+# Backup files
+*.bak
+*.sql
+*.tar
+*.zip
+*.gz


### PR DESCRIPTION
Introduces a .gitignore file to exclude OS, IDE, log, dependency, upload, environment, and backup files from version control.